### PR TITLE
Update miniconda setup script version.

### DIFF
--- a/.github/workflows/build-publish-aetherion.yml
+++ b/.github/workflows/build-publish-aetherion.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           auto-update-conda: true
 
       - name: Install cibuildwheel


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the Miniconda setup action and adjusts its configuration for better compatibility.

Dependency and configuration updates:

* [`.github/workflows/build-publish-aetherion.yml`](diffhunk://#diff-dd8f5559520a147affccb916b554b75255542793bf0513c47be327fb26b76e81L17-R19): Upgraded from `conda-incubator/setup-miniconda@v2` to `@v3` and changed the configuration option from `miniforge-variant: Mambaforge` to `miniforge-version: latest` for improved environment setup.