### PR TITLE
[bug#184] Remove Temporary empty tile after effects usage.

### DIFF
--- a/src/EffectsSystem.cpp
+++ b/src/EffectsSystem.cpp
@@ -1,6 +1,8 @@
 
 #include "EffectsSystem.hpp"
 
+#include <iostream>
+
 void EffectsSystem::processEffects(entt::registry& registry, VoxelGrid& voxelGrid,
                                    entt::dispatcher& dispatcher) {
     auto tileEffectsListView = registry.view<TileEffectsList>();
@@ -29,15 +31,20 @@ void EffectsSystem::processEffects(entt::registry& registry, VoxelGrid& voxelGri
         if (tileEffectsList.tileEffectsIDs.empty()) {
             registry.remove<TileEffectsList>(entity);
 
-            EntityTypeComponent* type = registry.try_get<EntityTypeComponent>(entity);
-            MatterContainer* matterContainer = registry.try_get<MatterContainer>(entity);
-            bool isEmptyTerrain{false};
-            if (type) {
-                isEmptyTerrain = (type->mainType == static_cast<int>(EntityEnum::TERRAIN) &&
-                                  type->subType0 == static_cast<int>(TerrainEnum::EMPTY));
-            }
+            Position pos = registry.get<Position>(entity);
+            EntityTypeComponent type =
+                voxelGrid.terrainGridRepository->getTerrainEntityType(pos.x, pos.y, pos.z);
+            MatterContainer matterContainer =
+                voxelGrid.terrainGridRepository->getTerrainMatterContainer(pos.x, pos.y, pos.z);
 
-            if (isEmptyTerrain && matterContainer == nullptr) {
+            bool isEmptyTerrain = (type.mainType == static_cast<int>(EntityEnum::TERRAIN) &&
+                                  type.subType0 == static_cast<int>(TerrainEnum::EMPTY));
+
+            bool emptyMatter = (matterContainer.TerrainMatter == 0 && matterContainer.WaterMatter == 0 &&
+                                matterContainer.WaterVapor == 0 && matterContainer.BioMassMatter == 0);
+            if (isEmptyTerrain && emptyMatter) {
+                std::cout << "[EffectsSystem] Empty terrain with no matter container at (" << pos.x << ", "
+                          << pos.y << ", " << pos.z << ")\n";
                 dispatcher.enqueue<KillEntityEvent>(entity);
             }
         }

--- a/src/physics/PhysicsMutators.hpp
+++ b/src/physics/PhysicsMutators.hpp
@@ -558,14 +558,14 @@ inline void removeEntityFromGrid(entt::registry& registry, VoxelGrid& voxelGrid,
     if (!isSpecialId && registry.valid(entity) &&
         registry.all_of<Position, EntityTypeComponent>(entity)) {
         std::ostringstream ossMessage;
-        ossMessage << "[processPhysics:Velocity] Removing entity from grid: " << entityId;
+        ossMessage << "[removeEntityFromGrid] Removing entity from grid: " << entityId;
         spdlog::get("console")->info(ossMessage.str());
         auto&& [pos, type] = registry.get<Position, EntityTypeComponent>(entity);
 
         int currentGridEntity = voxelGrid.getEntity(pos.x, pos.y, pos.z);
         if (currentGridEntity != entityId) {
             std::ostringstream ossMessage2;
-            ossMessage2 << "[processPhysics:Velocity] WARNING: Grid position (" << pos.x << ","
+            ossMessage2 << "[removeEntityFromGrid] WARNING: Grid position (" << pos.x << ","
                         << pos.y << "," << pos.z << ") contains entity " << currentGridEntity
                         << " but trying to remove entity " << entityId;
             spdlog::get("console")->info(ossMessage2.str());
@@ -582,7 +582,7 @@ inline void removeEntityFromGrid(entt::registry& registry, VoxelGrid& voxelGrid,
         }
     } else if (isSpecialId) {
         std::ostringstream ossMessage;
-        ossMessage << "[processPhysics:Velocity] Entity " << entityId
+        ossMessage << "[removeEntityFromGrid] Entity " << entityId
                    << " is a special ID, skipping grid removal.";
         spdlog::get("console")->info(ossMessage.str());
     } else if (!isSpecialId && registry.valid(entity)) {
@@ -590,13 +590,13 @@ inline void removeEntityFromGrid(entt::registry& registry, VoxelGrid& voxelGrid,
         EntityTypeComponent* entityType = registry.try_get<EntityTypeComponent>(entity);
         if (position) {
             std::ostringstream ossMessage;
-            ossMessage << "[processPhysics:Velocity] Entity " << entityId
+            ossMessage << "[removeEntityFromGrid] Entity " << entityId
                        << " has Position component at (" << position->x << ", " << position->y
                        << ", " << position->z << ").";
             spdlog::get("console")->info(ossMessage.str());
         } else {
             std::ostringstream ossMessage;
-            ossMessage << "[processPhysics:Velocity] Entity " << entityId
+            ossMessage << "[removeEntityFromGrid] Entity " << entityId
                        << " is missing Position component.";
             spdlog::get("console")->info(ossMessage.str());
             Position _pos = voxelGrid.terrainGridRepository->getPositionOfEntt(entity);
@@ -605,19 +605,19 @@ inline void removeEntityFromGrid(entt::registry& registry, VoxelGrid& voxelGrid,
 
         std::ostringstream ossMessage3;
         ossMessage3
-            << "[processPhysics:Velocity] Entity " << entityId
+            << "[removeEntityFromGrid] Entity " << entityId
             << " is missing Position or EntityTypeComponent, checking TerrainGridRepository.";
         spdlog::get("console")->info(ossMessage3.str());
         if (position->x == -1 && position->y == -1 && position->z == -1) {
             std::ostringstream ossMessage4;
-            ossMessage4 << "[processPhysics:Velocity] Could not find position of entity "
+            ossMessage4 << "[removeEntityFromGrid] Could not find position of entity "
                         << entityId << " in TerrainGridRepository, skipping grid removal.";
             spdlog::get("console")->info(ossMessage4.str());
             throw std::runtime_error(
                 "Entity is missing Position component and not found in TerrainGridRepository.");
         } else {
             std::ostringstream ossMessage5;
-            ossMessage5 << "[processPhysics:Velocity] Removing entity " << entityId
+            ossMessage5 << "[removeEntityFromGrid] Removing entity " << entityId
                         << " from grid using position from TerrainGridRepository at ("
                         << position->x << ", " << position->y << ", " << position->z << ").";
             spdlog::get("console")->info(ossMessage5.str());
@@ -625,7 +625,7 @@ inline void removeEntityFromGrid(entt::registry& registry, VoxelGrid& voxelGrid,
         }
     } else {
         std::ostringstream ossMessage;
-        ossMessage << "[processPhysics:Velocity] Entity " << entityId
+        ossMessage << "[removeEntityFromGrid] Entity " << entityId
                    << " is invalid, skipping grid removal.";
         spdlog::get("console")->info(ossMessage.str());
     }


### PR DESCRIPTION
This pull request improves the clarity and reliability of entity removal and effect processing in the voxel grid system. The main changes include more robust checks for empty terrain entities before removal, enhanced logging for debugging, and consistent log message labeling in the physics mutators.

**Effects processing improvements:**

* Changed the logic in `EffectsSystem::processEffects` to fetch `EntityTypeComponent` and `MatterContainer` directly from the `VoxelGrid`'s `terrainGridRepository` using the entity's position, rather than from the registry. This ensures the checks for empty terrain and matter containers are accurate and up-to-date.
* Added a debug message to notify when an empty terrain with no matter is found, aiding in debugging and tracking entity removals.
* Included the `<iostream>` header in `EffectsSystem.cpp` to support the new debug output.

**Logging consistency and clarity:**

* Updated all log messages in `removeEntityFromGrid` (in `PhysicsMutators.hpp`) to use the prefix `[removeEntityFromGrid]` instead of `[processPhysics:Velocity]`, making log output clearer and easier to trace to the correct function. [[1]](diffhunk://#diff-929d6f8536af31df39a364068b23a927855c6f7a68a8d8fdcbbef9e180239a8bL561-R568) [[2]](diffhunk://#diff-929d6f8536af31df39a364068b23a927855c6f7a68a8d8fdcbbef9e180239a8bL585-R599) [[3]](diffhunk://#diff-929d6f8536af31df39a364068b23a927855c6f7a68a8d8fdcbbef9e180239a8bL608-R628)